### PR TITLE
migration handling update:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,8 +10,9 @@
                  ;; environment
                  [environ "1.0.2"]
                  ;; database
-                 [org.clojure/java.jdbc "0.4.2"]
-                 [org.postgresql/postgresql "9.4.1208"]
+                 [org.clojure/java.jdbc "0.7.0"]
+                 [org.postgresql/postgresql "42.1.4"]
+                 [migratus "0.9.9"]
                  ;; ui
                  [hiccup "1.0.5"]
                  ;; middleware
@@ -22,7 +23,12 @@
                  [org.webjars/jquery "2.2.1"]
                  [ring-webjars "0.1.1"]]
 
-  :plugins [[lein-environ "1.0.2"]]
+  :plugins [[lein-environ "1.0.2"]
+            [migratus-lein "0.5.1"]]
+
+  :migratus {:store :database
+             :migration-dir "migrations"
+             :db ~(get (System/getenv) "DATABASE_URL")}
 
   :min-lein-version "2.0.0"
 

--- a/resources/migrations/20170828132748-add-items-table.down.sql
+++ b/resources/migrations/20170828132748-add-items-table.down.sql
@@ -1,0 +1,3 @@
+drop table items;
+--;;
+drop extension "uuid-ossp";

--- a/resources/migrations/20170828132748-add-items-table.up.sql
+++ b/resources/migrations/20170828132748-add-items-table.up.sql
@@ -1,0 +1,9 @@
+create extension "uuid-ossp";
+--;;
+create table items (
+id uuid primary key default uuid_generate_v4(),
+name text not null,
+description text not null,
+checked boolean not null default false,
+date_created timestamptz not null default now()
+);

--- a/src/listopia/core.clj
+++ b/src/listopia/core.clj
@@ -1,10 +1,8 @@
 (ns listopia.core
-  (:require [listopia.item.model :as model :refer [database-url]]
-            [listopia.item.middleware :refer [wrap-db
+  (:require [listopia.item.middleware :refer [wrap-db
                                               wrap-server]]
             [listopia.item.route :refer [routes]])
   (:require [ring.adapter.jetty :as jetty]
-            [environ.core :refer [env]]
             [ring.middleware.reload :refer [wrap-reload]]
             [ring.middleware.params :refer [wrap-params]]
             [ring.middleware.resource :refer [wrap-resource]]
@@ -27,12 +25,10 @@
 
 (defn -main
   ([] (-main 8000))
-  ([port] (model/create-table! database-url)
-          (jetty/run-jetty app
+  ([port] (jetty/run-jetty app
                            {:port (Integer. port)})))
 
 (defn -dev-main
   ([] (-dev-main 8000))
-  ([port] (model/create-table! database-url)
-          (jetty/run-jetty (wrap-reload #'app)
+  ([port] (jetty/run-jetty (wrap-reload #'app)
                            {:port (Integer. port)})))

--- a/src/listopia/db.clj
+++ b/src/listopia/db.clj
@@ -1,0 +1,5 @@
+(ns listopia.db
+  (:require [environ.core :refer [env]]))
+
+(def database-url
+  (env :database-url))

--- a/src/listopia/item/handler.clj
+++ b/src/listopia/item/handler.clj
@@ -1,11 +1,10 @@
 (ns listopia.item.handler
-  (:require [listopia.item.model :refer [database-url
-                                         create-item!
+  (:require [listopia.db :refer [database-url]]
+            [listopia.item.model :refer [create-item!
                                          read-items
                                          update-item!
                                          delete-item!]]
-            [listopia.item.view :refer [items-page]])
-  (:require [environ.core :refer [env]]))
+            [listopia.item.view :refer [items-page]]))
 
 (defn handle-index-items [req]
   (let [db database-url

--- a/src/listopia/item/middleware.clj
+++ b/src/listopia/item/middleware.clj
@@ -1,6 +1,5 @@
 (ns listopia.item.middleware
-  (:require [listopia.item.model :refer [database-url]])
-  (:require [environ.core :refer [env]]))
+  (:require [listopia.db :refer [database-url]]))
 
 (defn wrap-db [hdlr]
   (fn [req]

--- a/src/listopia/item/model.clj
+++ b/src/listopia/item/model.clj
@@ -1,22 +1,5 @@
 (ns listopia.item.model
-  (:require [clojure.java.jdbc :as db]
-            [environ.core :refer [env]]))
-
-(def database-url
-  (env :database-url))
-
-(defn create-table! [db]
-  (db/execute!
-   db
-   ["create extension if not exists \"uuid-ossp\""])
-  (db/execute!
-   db
-   ["create table if not exists items
-       (id uuid primary key default uuid_generate_v4(),
-        name text not null,
-        description text not null,
-        checked boolean not null default false,
-        date_created timestamptz not null default now())"]))
+  (:require [clojure.java.jdbc :as db]))
 
 (defn create-item! [db name description]
   (:id (first (db/query


### PR DESCRIPTION
- pulled table creation out of the items model
- pull the db connection def out of the items model
- placed db connection def in db namespace
- configured migratus and lein plugin for migration handling
- moved items table creation (and deps) into initial migration
- refactored items namespaces to use connection from db namespace